### PR TITLE
feat: implement secret flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # This is used to run the example only
 OIDC_ISSUER_URL=https://your-oidc-provider/.well-known/openid-configuration
 OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
 OIDC_REDIRECT_URI=http://localhost:8088/callback

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ import OidcTools from 'oidc-tools';
 // Initialize the library with your OIDC configuration
 const issuerURL = process.env.OIDC_ISSUER_URL;
 const clientId = process.env.OIDC_CLIENT_ID;
+const clientSecret = process.env.OIDC_CLIENT_SECRET;
 const redirectUri = process.env.OIDC_REDIRECT_URI;
 
 const { decodeToken, getLoginUrl, exchangeToken } = await OidcTools({
   issuerURL,
   clientId,
+  clientSecret,
   redirectUri,
   // Optional: cache options
   cache: true,
@@ -80,6 +82,7 @@ You can create a `.env` file in your project root with these variables:
 ```
 OIDC_ISSUER_URL=https://your-oidc-provider/.well-known/openid-configuration
 OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
 OIDC_REDIRECT_URI=https://your-app/callback
 ```
 
@@ -93,6 +96,7 @@ Initialize the OIDC tools library.
 
 - `issuerURL` (required): URL to the OIDC provider's well-known OpenID configuration.
 - `clientId` (optional): Your OAuth client ID, required for getLoginUrl.
+- `clientSecret` (optional): Your OAuth client secret for confidential clients.
 - `redirectUri` (optional): The URI to redirect to after authentication, required for getLoginUrl.
 - `scope` (optional): OAuth scopes to request. Default: `'openid profile email'`.
 - `cache` (optional): Boolean indicating whether to cache decoded tokens. Default: `true`.

--- a/examples/auth-flow.js
+++ b/examples/auth-flow.js
@@ -14,6 +14,7 @@ async function main() {
   // Get the OIDC configuration from environment variables
   const issuerURL = process.env.OIDC_ISSUER_URL;
   const clientId = process.env.OIDC_CLIENT_ID;
+  const clientSecret = process.env.OIDC_CLIENT_SECRET;
   const redirectUri = process.env.OIDC_REDIRECT_URI || 'http://localhost:8088/callback';
 
   if (!issuerURL || !clientId) {
@@ -27,6 +28,7 @@ async function main() {
   const { decodeToken, getLoginUrl, exchangeToken } = await OidcTools({
     issuerURL,
     clientId,
+    clientSecret,
     redirectUri,
     usePKCE: true // Enable PKCE
   });
@@ -113,6 +115,7 @@ async function main() {
         const tokens = await exchangeToken({
           code,
           codeVerifier: session.codeVerifier
+          // Client secret is automatically used from OidcTools initialization
         });
 
         const { id_token } = tokens;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ async function OidcTools(options: OidcToolsOptions): Promise<OidcToolsInstance> 
     cache = true,
     cacheDuration = DEFAULT_CACHE_DURATION,
     clientId,
+    clientSecret,
     redirectUri,
     scope = 'openid profile email',
     usePKCE = true
@@ -152,7 +153,9 @@ async function OidcTools(options: OidcToolsOptions): Promise<OidcToolsInstance> 
       throw new Error('Token endpoint not found in OIDC configuration');
     }
 
-    const { code, codeVerifier, clientSecret } = params;
+    const { code, codeVerifier, clientSecret: paramsClientSecret } = params;
+    // Use client secret from options or from params
+    const secretToUse = clientSecret || paramsClientSecret;
 
     const body = new URLSearchParams({
       grant_type: 'authorization_code',
@@ -171,8 +174,8 @@ async function OidcTools(options: OidcToolsOptions): Promise<OidcToolsInstance> 
     };
 
     // Add client authentication if client secret is provided
-    if (clientSecret) {
-      const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    if (secretToUse) {
+      const auth = Buffer.from(`${clientId}:${secretToUse}`).toString('base64');
       headers['Authorization'] = `Basic ${auth}`;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface OidcToolsOptions {
   cache?: boolean;
   cacheDuration?: number;
   clientId?: string;
+  clientSecret?: string;
   redirectUri?: string;
   scope?: string;
   usePKCE?: boolean;


### PR DESCRIPTION
This PR adds support for client secrets in the OIDC-Tools library, allowing integration with confidential clients that require client authentication during the token exchange process.

## Changes
- Added `clientSecret` parameter to the OidcTools initialization options
- Updated the `exchangeToken` function to use the client secret from initialization if available
- Enhanced Basic Auth implementation for token requests with client credentials
- Updated examples and documentation to demonstrate proper usage of client secrets

## Why?
Many OAuth providers require client authentication for confidential clients (server-side applications). This addition allows the library to work with a broader range of OIDC providers and authentication scenarios that enforce client authentication during the token exchange process.

## Documentation Updates
- Added client secret parameter in the README configuration examples
- Updated the API documentation to include the new parameter
- Added client secret to the example environment variables
