### PR TITLE
feat: implement getLogoutUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const clientId = process.env.OIDC_CLIENT_ID;
 const clientSecret = process.env.OIDC_CLIENT_SECRET;
 const redirectUri = process.env.OIDC_REDIRECT_URI;
 
-const { decodeToken, getLoginUrl, exchangeToken } = await OidcTools({
+const { decodeToken, getLoginUrl, exchangeToken, getLogoutUrl } = await OidcTools({
   issuerURL,
   clientId,
   clientSecret,
@@ -43,6 +43,12 @@ try {
 // Redirect user to the OAuth login page
 const { url, state, nonce, codeVerifier } = getLoginUrl();
 console.log(`Redirect user to: ${url}`);
+
+// Generate logout URL
+const logoutUrl = getLogoutUrl({
+  postLogoutRedirectUri: 'https://your-app/logged-out'
+});
+console.log(`Logout URL: ${logoutUrl}`);
 
 // In an http app, you could redirect like this:
 // res.writeHead(302, { 'Location': url });
@@ -140,6 +146,20 @@ An object containing:
 - `codeChallenge`: The PKCE code challenge (only if usePKCE is true)
 
 The state, nonce, and codeVerifier values should be stored in your session and verified when the user returns.
+
+### getLogoutUrl(params)
+
+Generates a URL to log the user out of the OAuth provider's session.
+
+**Parameters:**
+
+- `params` (optional): Object containing the following optional properties:
+  - `state` (string): Optional state value. If not provided, a secure random value will be generated.
+  - `postLogoutRedirectUri` (string): Optional URI to redirect to after logout. If not provided, the redirectUri from initialization will be used.
+
+**Returns:**
+
+A string URL to redirect the user to for logout.
 
 ### exchangeToken(params)
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "jose": "^6.0.10"
   },
   "devDependencies": {
-    "@types/node": "^22.13.11",
-    "dotenv": "^16.4.7",
-    "typescript": "^5.8.2"
+    "@types/node": "^22.14.1",
+    "dotenv": "^16.5.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface OidcToolsInstance {
     codeVerifier?: string;
     codeChallenge?: string;
   };
+  getLogoutUrl: (params?: { state?: string; postLogoutRedirectUri?: string }) => string;
   exchangeToken: (params: {
     code: string;
     codeVerifier?: string;


### PR DESCRIPTION
This pull request introduces a new feature to generate logout URLs in the `OidcTools` library, along with some minor updates to dependencies and imports. The key changes include adding the `getLogoutUrl` function, updating related documentation, and performing minor dependency and code improvements.

### New Feature: Logout URL Generation

* Added a `getLogoutUrl` function to the `OidcTools` instance, allowing users to generate a URL for logging out of the OAuth provider's session. This includes support for optional parameters like `state` and `postLogoutRedirectUri`. (`src/index.ts` - [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R131-R149) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R218); `src/types.ts` - [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR25)

### Documentation Updates

* Updated the `README.md` to include usage instructions for the new `getLogoutUrl` function, including parameter descriptions and examples. (`README.md` - [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R52) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R150-R163)

### Dependency Updates

* Updated `@types/node`, `dotenv`, and `typescript` to newer versions in `package.json` to ensure compatibility and address potential issues. (`package.json` - [package.jsonL40-R42](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R42))

### Code Improvements

* Updated the `crypto` import to use the `node:` prefix for consistency with modern Node.js module resolution. (`src/index.ts` - [src/index.tsL3-R3](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L3-R3))